### PR TITLE
Fix Log Message Spam

### DIFF
--- a/Updater/build.gradle
+++ b/Updater/build.gradle
@@ -3,11 +3,14 @@ plugins {
     id "application"
 }
 
-targetCompatibility = 11
-sourceCompatibility = 11
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}
 
 group = 'smlauncher.updater'
-mainClassName = 'smlauncher.StarMadeLauncher'
+mainClassName = 'smlauncher.updater.LauncherUpdater'
 
 repositories {
     mavenCentral()
@@ -15,7 +18,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'commons-io:commons-io:2.11.0'
+    implementation 'commons-io:commons-io:2.16.1'
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ java {
 
 application {
 	mainClassName = 'smlauncher.StarMadeLauncher'
-	mainModule = 'smlauncher'
+//	mainModule = 'smlauncher'
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,11 @@ group 'smlauncher'
 mainClassName = 'smlauncher.StarMadeLauncher'
 version = '3.1.2'
 
-sourceCompatibility = 18
-targetCompatibility = 18
+java {
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(18)
+	}
+}
 
 application {
 	mainClassName = 'smlauncher.StarMadeLauncher'
@@ -25,12 +28,12 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.codehaus.plexus:plexus-archiver:4.10.0'
-	implementation 'commons-io:commons-io:2.16.1'
-	implementation 'org.json:json:20240303'
-	implementation 'it.unimi.dsi:fastutil:8.5.14'
-	implementation 'org.jasypt:jasypt:1.9.3'
 	implementation 'com.formdev:flatlaf:3.5.1'
+	implementation 'commons-io:commons-io:2.16.1'
+	implementation 'it.unimi.dsi:fastutil:8.5.14'
+	implementation 'org.codehaus.plexus:plexus-archiver:4.10.0'
+	implementation 'org.jasypt:jasypt:1.9.3'
+	implementation 'org.json:json:20240303'
 	implementation 'org.panteleyev:jpackage-gradle-plugin:1.6.0'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id "java"
 	id "application"
 	id "org.panteleyev.jpackageplugin" version "1.6.0"
-	id 'com.github.johnrengelman.shadow' version '7.0.0'
+	id 'com.github.johnrengelman.shadow' version "8.1.1"
 }
 
 group 'smlauncher'
@@ -26,11 +26,11 @@ repositories {
 
 dependencies {
 	implementation 'org.codehaus.plexus:plexus-archiver:4.10.0'
-	implementation 'commons-io:commons-io:2.11.0'
-	implementation 'org.json:json:20231013'
-	implementation 'it.unimi.dsi:fastutil:8.5.12'
+	implementation 'commons-io:commons-io:2.16.1'
+	implementation 'org.json:json:20240303'
+	implementation 'it.unimi.dsi:fastutil:8.5.14'
 	implementation 'org.jasypt:jasypt:1.9.3'
-	implementation 'com.formdev:flatlaf:3.0'
+	implementation 'com.formdev:flatlaf:3.5.1'
 	implementation 'org.panteleyev:jpackage-gradle-plugin:1.6.0'
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/smlauncher/news/LauncherNewsPanel.java
+++ b/src/main/java/smlauncher/news/LauncherNewsPanel.java
@@ -18,6 +18,8 @@ import java.util.ArrayList;
  */
 public class LauncherNewsPanel extends JPanel {
 
+	public static final boolean PRINT_HTML_MESSAGES = false;
+
 	public LauncherNewsPanel() {
 		super(true);
 		setBackground(Palette.paneColor);
@@ -41,8 +43,15 @@ public class LauncherNewsPanel extends JPanel {
 			lines.add("<p><a href=\"" + post.getUrl() + "\">Posted on " + ldt.toString() + " by " + post.getAuthor() + "</a></p>");
 			lines = BBCodeToHTMLConverter.insertColors(lines, "#eeeeee");
 			lines.add("<hr>");
-			for(String line : lines) sb.append(line);
+
+			for(String line : lines) {
+				sb.append(line);
+				if (PRINT_HTML_MESSAGES) {
+					System.out.println(line);
+				}
+			}
 		}
+
 		htmlPanel.setText(sb.toString());
 		add(htmlPanel, BorderLayout.CENTER);
 		revalidate();

--- a/src/main/java/smlauncher/starmade/ChecksumFile.java
+++ b/src/main/java/smlauncher/starmade/ChecksumFile.java
@@ -16,8 +16,6 @@ public class ChecksumFile {
 	int toExecute;
 	private int failed;
 
-	public static final boolean PRINT_DOWNLOAD_MILESTONES = true;
-
 	public void parse(BufferedReader in) throws IOException {
 		String line;
 
@@ -165,7 +163,7 @@ public class ChecksumFile {
 	}
 
 	private static void printUpdaterMessage(String message) {
-		if (PRINT_DOWNLOAD_MILESTONES) {
+		if (GameUpdater.PRINT_DOWNLOAD_MILESTONES) {
 			System.err.println("[UPDATER] " + message);
 		}
 	}

--- a/src/main/java/smlauncher/starmade/ChecksumFile.java
+++ b/src/main/java/smlauncher/starmade/ChecksumFile.java
@@ -83,9 +83,7 @@ public class ChecksumFile {
 	}
 
 	public void download(boolean force, String buildPath, File installDir, String installDirStr, FileDowloadCallback cb) throws NoSuchAlgorithmException, IOException {
-
-		ArrayList<ChecksumFileEntry> checksumsToDownload = new ArrayList<ChecksumFileEntry>();
-
+		ArrayList<ChecksumFileEntry> checksumsToDownload = new ArrayList<>();
 		cb.update("Determining files to download... ");
 
 		FileUpdateTotal o = new FileUpdateTotal();
@@ -111,7 +109,6 @@ public class ChecksumFile {
 		running.clear();
 		for(int i = 0; i < checksumsToDownload.size(); i++) {
 			ChecksumFileEntry e = checksumsToDownload.get(i);
-
 			e.index = i;
 
 			synchronized(running) {
@@ -119,28 +116,22 @@ public class ChecksumFile {
 //				System.err.println("STARTED: "+e+"; "+running);
 				assert (add);
 			}
-			pool.execute(new Runnable() {
-
-				@Override
-				public void run() {
-
-					try {
-						o.index = e.index;
-						o.total = checksumsToDownload.size();
-						e.download(force, buildPath, installDir, installDirStr, cb, o);
-					} catch(Exception e1) {
-						e1.printStackTrace();
-						failed++;
-					}
-					synchronized(running) {
-						boolean remove = running.remove(e);
-//						System.err.println("FINISHED: "+e);
-						assert (remove);
-					}
-					toExecute--;
+			pool.execute(() -> {
+				try {
+					o.index = e.index;
+					o.total = checksumsToDownload.size();
+					e.download(force, buildPath, installDir, installDirStr, cb, o);
+				} catch(Exception e1) {
+					e1.printStackTrace();
+					failed++;
 				}
+				synchronized(running) {
+					boolean remove = running.remove(e);
+//						System.err.println("FINISHED: "+e);
+					assert (remove);
+				}
+				toExecute--;
 			});
-
 		}
 
 		while(toExecute > 0) {

--- a/src/main/java/smlauncher/starmade/ChecksumFileEntry.java
+++ b/src/main/java/smlauncher/starmade/ChecksumFileEntry.java
@@ -11,8 +11,6 @@ public class ChecksumFileEntry {
 	public final String relativePath;
 	protected int index;
 
-	public static final boolean PRINT_DOWNLOAD_LOGS = false;
-
 	public ChecksumFileEntry(long size, String checksum, String relativePath) {
 		this.size = size;
 		this.checksum = checksum;
@@ -155,7 +153,7 @@ public class ChecksumFileEntry {
 	}
 
 	private static void printUpdaterMessage(String message) {
-		if (PRINT_DOWNLOAD_LOGS) {
+		if (GameUpdater.PRINT_ALL_DOWNLOADS) {
 			System.err.println("[UPDATER] " + message);
 		}
 	}

--- a/src/main/java/smlauncher/starmade/GameUpdater.java
+++ b/src/main/java/smlauncher/starmade/GameUpdater.java
@@ -28,6 +28,9 @@ public class GameUpdater extends Observable {
 	public static String LAUNCHER_VERSION_SITE = "http://files.star-made.org/version";
 	public static String MIRROR_SITE = "http://files.star-made.org/mirrors";
 
+	public static final boolean PRINT_ALL_DOWNLOADS = false;
+	public static final boolean PRINT_DOWNLOAD_MILESTONES = true;
+
 	public final ArrayList<IndexFileEntry> versions = new ArrayList<>();
 	private final ArrayList<String> mirrorURLs = new ArrayList<>();
 	private final StarMadeBackupTool backup = new StarMadeBackupTool();

--- a/src/main/java/smlauncher/starmade/GameUpdater.java
+++ b/src/main/java/smlauncher/starmade/GameUpdater.java
@@ -27,6 +27,7 @@ public class GameUpdater extends Observable {
 	public static String FILES_URL = "http://files.star-made.org/";
 	public static String LAUNCHER_VERSION_SITE = "http://files.star-made.org/version";
 	public static String MIRROR_SITE = "http://files.star-made.org/mirrors";
+
 	public final ArrayList<IndexFileEntry> versions = new ArrayList<>();
 	private final ArrayList<String> mirrorURLs = new ArrayList<>();
 	private final StarMadeBackupTool backup = new StarMadeBackupTool();
@@ -116,24 +117,11 @@ public class GameUpdater extends Observable {
 	}
 
 	private static String getJavaExec() {
-		if(smlauncher.util.OperatingSystem.getCurrent() == smlauncher.util.OperatingSystem.WINDOWS) {
+		if(OperatingSystem.getCurrent() == OperatingSystem.WINDOWS) {
 			return "javaw";
 		} else {
 			return "java";
 		}
-	}
-
-	public static ChecksumFile getChecksums(String relPath) throws IOException {
-		URL urlVersion = new URL(relPath + "/checksums");
-		URLConnection openConnection = urlVersion.openConnection();
-		openConnection.setRequestProperty("User-Agent", "StarMade-Updater_" + StarMadeLauncher.LAUNCHER_VERSION);
-		openConnection.setConnectTimeout(10000);
-		openConnection.setReadTimeout(10000);
-		BufferedReader in = new BufferedReader(new InputStreamReader(new BufferedInputStream(openConnection.getInputStream()), StandardCharsets.UTF_8));
-		ChecksumFile f = new ChecksumFile();
-		f.parse(in);
-		in.close();
-		return f;
 	}
 
 	@Override
@@ -469,6 +457,19 @@ public class GameUpdater extends Observable {
 		in.close();
 		e.text = b.toString();
 		return e;
+	}
+
+	public static ChecksumFile getChecksums(String relPath) throws IOException {
+		URL urlVersion = new URL(relPath + "/checksums");
+		URLConnection openConnection = urlVersion.openConnection();
+		openConnection.setRequestProperty("User-Agent", "StarMade-Updater_" + StarMadeLauncher.LAUNCHER_VERSION);
+		openConnection.setConnectTimeout(10000);
+		openConnection.setReadTimeout(10000);
+		BufferedReader in = new BufferedReader(new InputStreamReader(new BufferedInputStream(openConnection.getInputStream()), StandardCharsets.UTF_8));
+		ChecksumFile f = new ChecksumFile();
+		f.parse(in);
+		in.close();
+		return f;
 	}
 
 }

--- a/src/main/java/smlauncher/util/BBCodeToHTMLConverter.java
+++ b/src/main/java/smlauncher/util/BBCodeToHTMLConverter.java
@@ -1,5 +1,7 @@
 package smlauncher.util;
 
+import smlauncher.news.LauncherNewsPanel;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -17,7 +19,6 @@ public class BBCodeToHTMLConverter {
 			line = line.replace("<*>", "<li>");
 
 			output.add(line);
-			System.out.println(line);
 		}
 		return output;
 	}


### PR DESCRIPTION
- Launcher news panel no longer prints HTML messages from steam
- Game updater no longer prints update messages for each file (fixes #10)
- Game updater occasionally prints update messages for each 10% of files downloaded
- These options can be changed manually using hardcoded constants
- Update Gradle, plugins, and dependencies to latest